### PR TITLE
Add support for --baseline to browser-specific-failures.js

### DIFF
--- a/lib/browser-specific.js
+++ b/lib/browser-specific.js
@@ -256,7 +256,11 @@ function scoreTopLevelTest(browserTests) {
 
 // Scores a particular WPT test for a set of browsers, returning an array of
 // scores for each browser in the same order as |browserTests|.
-function scoreTest(browserTests) {
+function scoreTest(browserTests, testPath, testFilter) {
+  if (testFilter && !testFilter(testPath)) {
+    return new Array(browserTests.length).fill(0);
+  }
+
   const cacheKey = browserTests.map(test => test.id).join('-');
   if (testsScoreCache.has(cacheKey)) {
     return testsScoreCache.get(cacheKey);
@@ -286,7 +290,7 @@ function scoreTest(browserTests) {
 
 // Walks a set of trees, one per browser, scoring them for browser-specific
 // failures of tests in the trees.
-function walkTrees(browserTrees) {
+function walkTrees(browserTrees, path, testFilter) {
   const cacheKey = browserTrees.map(tree => tree.id).join('-');
   if (treesScoreCache.has(cacheKey)) {
     return treesScoreCache.get(cacheKey);
@@ -315,8 +319,10 @@ function walkTrees(browserTrees) {
     // If we are looking at the same test across all browsers, but they aren't
     // the exact same objects, they need to be scored!
     if (browserTests.every(t => t.key() === browserTests[0].key())) {
+      const testPath = path + '/' + browserTests[0].key();
       try {
-        const testScores = scoreTest(browserTests.map(t => t.value()));
+        const testScores = scoreTest(
+            browserTests.map(t => t.value()), testPath, testFilter);
         scores = scores.map((v, i) => v + testScores[i]);
         browserTests.forEach(t => t.moveNext());
         continue;
@@ -354,8 +360,9 @@ function walkTrees(browserTrees) {
     // If all the iterators are pointing at the same directory (subtree), then
     // we should recurse into those subtrees to score them.
     if (browserSubtrees.every(s => s.key() == browserSubtrees[0].key())) {
+      const newPath = path + '/' + browserSubtrees[0].key();
       const subtreeScores = walkTrees(
-          browserSubtrees.map(s => s.value()));
+          browserSubtrees.map(s => s.value()), newPath, testFilter);
       scores = scores.map((v, i) => v + subtreeScores[i]);
       browserSubtrees.forEach(s => s.moveNext());
       continue;
@@ -389,8 +396,12 @@ function walkTrees(browserTrees) {
 // expectedBrowsers: the set of browsers that should be (exactly) represented in
 //                   runs. If a browser is missing, an exception will be thrown.
 //
+// testFilter: if non-null, a function used to filter which tests are
+//             considered. Called with the test path; return true to include
+//             the test, false to exclude it.
+//
 // Returns a map from product name to score.
-function scoreBrowserSpecificFailures(runs, expectedBrowsers) {
+function scoreBrowserSpecificFailures(runs, expectedBrowsers, {testFilter = null} = {}) {
   // First, verify that the expected browsers are seen in |runs|.
   const seenBrowsers = new Set();
   for (const run of runs) {
@@ -413,7 +424,7 @@ function scoreBrowserSpecificFailures(runs, expectedBrowsers) {
 
 
   // Now do the actual walk to score the runs.
-  const scores = walkTrees(runs.map(run => run.tree));
+  const scores = walkTrees(runs.map(run => run.tree), '', testFilter);
   return new Map(scores.map((score, i) => [runs[i].browser_name, score]));
 }
 

--- a/test/browser-specific.js
+++ b/test/browser-specific.js
@@ -389,4 +389,31 @@ describe('browser-specific.js', () => {
       assert.deepEqual(scores, new Map([['chrome', 0], ['firefox', 0]]));
     });
   });
+
+  describe('Filtering Tests', () => {
+    it('should ignore tests that are filtered', () => {
+      const expectedBrowsers = new Set(['chrome', 'firefox']);
+
+      let chromeTree = new TreeBuilder()
+          .addTest('TestA', 'PASS')
+          .addTest('TestB', 'FAIL')
+          .build();
+      let firefoxTree = new TreeBuilder()
+          .addTest('TestA', 'FAIL')
+          .addTest('TestB', 'PASS')
+          .build();
+      let runs = [
+          { browser_name: 'chrome', tree: chromeTree },
+          { browser_name: 'firefox', tree: firefoxTree },
+      ];
+
+      // This should be a BSF in each browser, but we filter TestA so there is
+      // only a BSF in Chrome.
+      let options = {
+          testFilter: (path) => { return path != '/TestA'; }
+      };
+      let scores = browserSpecific.scoreBrowserSpecificFailures(runs, expectedBrowsers, options);
+      assert.deepEqual(scores, new Map([['chrome', 1], ['firefox', 0]]));
+    });
+  });
 });


### PR DESCRIPTION
This command line flag causes the results to be filtered to only include
tests that existed on the baseline date. In essence this is a rough form
of time-travel, allowing us to backdate a modern WPT run to a previous
date, to better see how a browser has progressed over time (by ignoring
newly added tests).